### PR TITLE
Make Orjan come from Norway

### DIFF
--- a/data/players.yaml
+++ b/data/players.yaml
@@ -462,7 +462,7 @@
     de:
       - '357795' # DracKeN
 - name: TheViper
-  country: de
+  country: 'no'
   esportsearnings: 12243
   aoeelo: 29
   liquipedia: TheViper


### PR DESCRIPTION
I think he was already set to being from Norway from aoe2net, so let's do it as well here?

Was a bit confused searching for Viper here:
https://aoe2recs.com/players/120