### PR TITLE
Swapped SongSong's name and aka

### DIFF
--- a/data/players.yaml
+++ b/data/players.yaml
@@ -1165,10 +1165,10 @@
       - '123321654'
       - '123189353'
       - '123741316'
-- name: 'KuTaTaXoa'
+- name: 'SongSong'
   country: vn
   aka:
-    - 'SongSong'
+    - 'KuTaTaXoa'
   twitch: https://www.twitch.tv/songsongaoede
   platforms:
     voobly:

--- a/data/players.yaml
+++ b/data/players.yaml
@@ -1166,7 +1166,7 @@
       - '123189353'
       - '123741316'
 - name: 'KuTaTaXoa'
-  country: cn
+  country: vn
   aka:
     - 'SongSong'
   twitch: https://www.twitch.tv/songsongaoede


### PR DESCRIPTION
Magistone messaged me earlier on discord for this suggestion.

Kutataxoa was his old voobly aka, and since DE he switched to his current name SongSong.
It would make more sense to swap the `name` and `aka` for him.