### PR TITLE
[Changed] Added DracKen's twitch, set aka for him

### DIFF
--- a/data/players.yaml
+++ b/data/players.yaml
@@ -451,8 +451,11 @@
       - '123961442'
     de:
       - '575722'
-- name: DraconT
+- name: DracKeN
+  aka:
+    - DraconT
   country: cz
+  twitch: https://wwww.twitch.tv/drackentv
   aoeelo: 100
   platforms:
     voobly:


### PR DESCRIPTION
DracKen said in Nili's stream (beginning of second game of the day for koth8) while casting with him that he changed his name because he thinks `DracKen` sounds better. So I would propose to "identify" him with DracKen and keep DraconT as an aka.

