### PR TITLE
aoe-elo restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Most data changes rarely. However, the player data needs to be consistently upda
 Only notable players may be added. Notability is defined as meeting at least one of the following criteria:
 
 1. Has a page on the [Age of Empires Liquipedia](https://liquipedia.net/ageofempires/Main_Page).
-1. Is listed on [Aoe Tournament Elo](https://aoe-elo.com/).
-1. Was a top 200 player on the [primary 1v1 Age of Empires II competitive ladder](https://aoe2.net/#aoe2de-leaderboard-rm-1v1) for at least three months.
+1. Was ever a top 200 player listed on [Aoe Tournament Elo](https://aoe-elo.com/).
+1. Was ever a top 200 player on the [primary 1v1 Age of Empires II competitive ladder](https://aoe2.net/#aoe2de-leaderboard-rm-1v1) for at least three months.
 1. Is a [Twitch Partner](https://www.twitch.tv/p/partners/) and primarily streams Age of Empires II.
 
 Other players may be added based on the maintainer's discretion for the benefit of the community at large.


### PR DESCRIPTION
Add rank cap of 200 for aoe-elo requirement. Updates language to be a bit more accurate.